### PR TITLE
Fix config tests.

### DIFF
--- a/tests/config.test.json
+++ b/tests/config.test.json
@@ -3,15 +3,15 @@
   "kafka_group_id": "syslog-consumers",
   "kafka_max_records_poll": 500,
   "batch_size": 30000,
-  
+
   "handler": {
-    "type": "cgn_ec_consumer.handlers.nfware.NFWareSyslogHandler",
+    "type": "NFWareSyslogHandler",
     "options": {}
   },
-  
+
   "outputs": [
     {
-      "type": "cgn_ec_consumer.outputs.timescaledb.TimeScaleDBOutput",
+      "type": "TimeScaleDBOutput",
       "options": {
         "address": "tsdb",
         "port": 5432,
@@ -22,7 +22,7 @@
       }
     },
     {
-      "type": "cgn_ec_consumer.outputs.http.HTTPOutput",
+      "type": "HTTPWebhookOutput",
       "options": {
         "url": "http://example.com/api/metrics",
         "headers": {

--- a/tests/config.test.yaml
+++ b/tests/config.test.yaml
@@ -6,12 +6,12 @@ batch_size: 30000
 
 # Handler Configuration
 handler:
-  type: "cgn_ec_consumer.handlers.nfware.NFWareSyslogHandler"
+  type: "NFWareSyslogHandler"
   options: {}  # Additional parameters if needed
 
 # Outputs Configuration
 outputs:
-  - type: "cgn_ec_consumer.outputs.timescaledb.TimeScaleDBOutput"
+  - type: "TimeScaleDBOutput"
     options:
       address: "tsdb"
       port: 5432
@@ -21,7 +21,7 @@ outputs:
       batch_size: 30000
 
   # Example HTTP Output
-  - type: "cgn_ec_consumer.outputs.http.HTTPOutput"
+  - type: "HTTPWebhookOutput"
     options:
       url: "http://example.com/api/metrics"
       headers:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,7 +10,7 @@ def test_config_json(yaml_config: Settings):
     assert yaml_config.BATCH_SIZE
 
     assert yaml_config.HANDLER
-    assert len(yaml_config.OUTPUTS) == 2
+    assert len(yaml_config.OUTPUTS) == 3
 
 
 def test_config_yaml(json_config: Settings):


### PR DESCRIPTION
Some changes made in c2d31e644e69092c43440afe0352894356f68b30 look to have broken the ability to run `poetry run pytest` successfully as the required values in the config file changed.

This PR fixes those test configs, and then also fixes one of the `assert`s in the actual test.